### PR TITLE
Separate auth for separate redis nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ To see this in action,
   the node it detects is freshest, set that to master, and the others to slaves!
 - Bring up 6380, and it will be added as standby for failover.
 
-API difference: createClient
-============================
+API differences
+===============
+
+`createClient`
+--------------
 
 In **haredis**, `createClient` works like this:
 
@@ -70,6 +73,19 @@ additionally supports:
 
 - `haredis_db_num` {Number} database number that **haredis** should store metadata
   in (such as an opcounter). Defaults to `15`.
+
+`auth`
+------
+
+`auth` works like this:
+
+```javascript
+function auth({host/port to password object}, callback)
+```
+
+The first argument can be an object of hosts, ports mapped to passwords
+(i.e., `{'1.2.3.1:6379': 'pass1', '1.2.3.3:6379': 'pass2'}`), or just the password
+string.
 
 Load-balancing
 ==============

--- a/index.js
+++ b/index.js
@@ -319,9 +319,19 @@ RedisHAClient.prototype.auth = RedisHAClient.prototype.AUTH = function () {
   var args = Array.prototype.slice.call(arguments);
   var self = this;
   this.auth_callback = args[1];
-  this.nodes.forEach(function(node) {
-    node.auth_pass = args[0];
-  });
+  var authList = args[0];
+  if (typeof authList == 'object'){
+    this.nodes.forEach(function(node) {
+      var auth_pass = authList[node.host + ':' + node.port];
+      if (auth_pass) {
+        node.auth_pass = auth_pass;
+      }
+    });
+  } else {
+    this.nodes.forEach(function(node) {
+      node.auth_pass = authList;
+    });
+  }
 };
 
 RedisHAClient.prototype.isRead = function(command, args) {


### PR DESCRIPTION
The code seems to assume that all redis instances use the same auth. For my (unique?) case, it's not the same.
