### PR TITLE
Allow "slaveof no one" in redis config

### DIFF
--- a/index.js
+++ b/index.js
@@ -592,7 +592,7 @@ RedisHAClient.prototype.orientate = function(why) {
           err = new Error(node + ' still loading');
           return cb(err);
         }
-        else if (info.master_host) {
+        else if (info.master_port && info.master_port !== '0') {
           // Resolve the host to prevent false duplication
           Node.resolveHost(info.master_host, function(err, host) {
             if (err) {


### PR DESCRIPTION
I'm trying to make it really easy for my team to try out haredis. So I'm making [Get You Some Redis Cluster](https://github.com/sheldonh/gysrc).

When I run haredis' test suite with "make test-cluster", I get this error:

```
Note: test requires redis daemons running locally on ports 6380, 6381, and 6382!
client: Error: getaddrinfo ENOTFOUND
    at errnoException (dns.js:37:11)
    at Object.onanswer [as oncomplete] (dns.js:124:16)
Uncaught exception: AssertionError: true == false
    at process.<anonymous> (/home/sheldonh/git/haredis/test.js:1429:12)
    at process.EventEmitter.emit (events.js:95:17)
    at process.exit (node.js:707:17)
    at RedisHAClient.<anonymous> (/home/sheldonh/git/haredis/test.js:1409:13)
    at RedisHAClient.EventEmitter.emit (events.js:95:17)
    at Node.<anonymous> (/home/sheldonh/git/haredis/index.js:516:14)
    at Node.EventEmitter.emit (events.js:95:17)
    at RedisClient.<anonymous> (/home/sheldonh/git/haredis/lib/node.js:65:10)
    at RedisClient.EventEmitter.emit (events.js:95:17)
    at /home/sheldonh/git/haredis/index.js:599:27
make: *** [test-cluster] Error 1
```

This comes from index.js, where we do

```
Node.resolveHost(info.master_host, function(err, host) { ... }
```

If the default master instance (6380) is configured with "slaveof no one", then info.master_host is "no".

And indeed, when I tcpdump, I see that my host sent out a DNS request for the hostname "no.hearnlan". That looks like it tried to resolve "no", appending the localdomain.

This pull request changes the guard condition from inspecting master_host to inspecting master_port. With this change, I get past the DNS problem, to a new error in the multi_1 test. But I bet that's unrelated and will raise a separate issue / pull request for that once I have a handle on it.
