### PR TITLE
Upgrade to node-redis 0.8.3, and apply fix to support it

### DIFF
--- a/lib/multi.js
+++ b/lib/multi.js
@@ -10,12 +10,12 @@ util.inherits(HAMulti, redis.Multi);
 // Defer execution until ready.
 HAMulti.prototype.exec = function(callback) {
   var self = this;
-  if (this.client.ready) {
+  if (this._client.ready) {
     redis.Multi.prototype.exec.call(this, callback);
     incrOpcounter();
   }
   else {
-    this.client.once('ready', function() {
+    this._client.once('ready', function() {
       redis.Multi.prototype.exec.call(self, callback);
       incrOpcounter();
     });
@@ -25,14 +25,14 @@ HAMulti.prototype.exec = function(callback) {
   function incrOpcounter() {
     var incr = 0;
     self.queue.forEach(function(args) {
-      if (!self.client.isRead(args[0])) {
+      if (!self._client.isRead(args[0])) {
         incr++;
       }
     });
     if (incr) {
-      self.client.incrOpcounter(incr, function(err) {
+      self._client.incrOpcounter(incr, function(err) {
         if (err) {
-          self.client.master.emit('error', err);
+          self._client.master.emit('error', err);
         }
       });
     }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "redis": "~0.7.2",
+    "redis": "~0.8.3",
     "async": "~0.1.22",
     "pkginfo": "~0.2.3"
   },


### PR DESCRIPTION
The current haredis supports only node-redis up to 0.7.x. This commit has all the changes required to support the latest node-redis (0.8.3 as of time of writing). The changes are very trivial....
