### PR TITLE
fixed node.status sometimes undefined

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -21,6 +21,8 @@ function Node(spec, options) {
     self.options[k] = options[k];
   });
 
+  this.setStatus('initializing');
+
   if (this.host.match(/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/)) {
     this.connect();
   }
@@ -61,7 +63,6 @@ Node.parseInfo = function(reply) {
 
 Node.prototype.connect = function() {
   var self = this;
-  this.setStatus('initializing');
   this.client = redis.createClient(this.port, this.host, this.options);
   if (this.auth_pass) {
     this.client.auth(this.auth_pass);


### PR DESCRIPTION
If a node connects before another node finishes its DNS lookup, the 'status' property of the node performing the DNS lookup will still be undefined, causing the 'responded' getter to return an erroneous value.

Moving the call to setStatus() before the DNS lookup fixes the issue.
